### PR TITLE
Use SSL

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 func (c *Config) NewClient() (*tdClient.TDClient, error) {
 	client, err := tdClient.NewTDClient(tdClient.Settings{
 		ApiKey:    c.APIKey,
+		Ssl:       true,
 		UserAgent: "Terraform for Treasure Data",
 	})
 	if err != nil {


### PR DESCRIPTION
Unfortunately, td-client-go use `http` when `Ssl` is not set to `true`.
Let's set `Ssl` explicitly.

This may break something (for example blocked by firewall) but I believe this is worth setting and we don't need any options to set `false`.